### PR TITLE
feat(win32-titelbar-theme): Add immersive title bar theme support for…

### DIFF
--- a/src/MewUI/Native/Dwmapi.cs
+++ b/src/MewUI/Native/Dwmapi.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Aprillz.MewUI.Native;
+
+internal static partial class Dwmapi
+{
+    private const string LibraryName = "dwmapi.dll";
+
+    /// <summary>
+    /// DWMWINDOWATTRIBUTE enumeration for DwmSetWindowAttribute.
+    /// </summary>
+    public enum DwmWindowAttribute : uint
+    {
+        /// <summary>
+        /// Use immersive dark mode (Windows 10 build 17763-18985).
+        /// </summary>
+        DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19,
+
+        /// <summary>
+        /// Use immersive dark mode (Windows 10 build 18985+).
+        /// </summary>
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+    }
+
+    /// <summary>
+    /// Sets the value of Desktop Window Manager (DWM) attributes for a window.
+    /// </summary>
+    [LibraryImport(LibraryName)]
+    internal static partial int DwmSetWindowAttribute(
+        nint hwnd,
+        DwmWindowAttribute dwAttribute,
+        ref int pvAttribute,
+        int cbAttribute);
+}
+

--- a/src/MewUI/Native/User32.cs
+++ b/src/MewUI/Native/User32.cs
@@ -199,6 +199,9 @@ internal static partial class User32
     public static partial nint GetFocus();
 
     [LibraryImport(LibraryName)]
+    public static partial nint GetForegroundWindow();
+
+    [LibraryImport(LibraryName)]
     public static partial nint SetCapture(nint hWnd);
 
     [LibraryImport(LibraryName)]

--- a/src/MewUI/Platform/Win32/Win32ImmersiveThemeManager.cs
+++ b/src/MewUI/Platform/Win32/Win32ImmersiveThemeManager.cs
@@ -1,0 +1,57 @@
+﻿using Aprillz.MewUI.Native;
+using Aprillz.MewUI.Native.Constants;
+using static Aprillz.MewUI.Native.Dwmapi;
+
+namespace Aprillz.MewUI.Platform.Win32;
+
+internal sealed class Win32ImmersiveThemeManager
+{
+    private static readonly bool ImmersiveThemeSupportedByVersion = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763);
+    private static readonly bool Is20H1OrGreater = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 18985);
+    private static readonly bool Is11OrGreater = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000);
+
+    private static readonly DwmWindowAttribute ImmersiveAttribute = Is20H1OrGreater
+        ? DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE
+        : DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1;
+
+    /// <summary>
+    /// Checks whether immersive themes are supported based on the operating system version.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the Windows version meets the minimum requirement for immersive themes; <br/> 
+    /// otherwise <c>false</c>.
+    /// </returns>
+    public static bool IsImmersiveThemeSupportedByVersion() => ImmersiveThemeSupportedByVersion;
+
+    /// <summary>
+    /// Enables the window to use the immersive theme mode colors for the title bar.
+    /// </summary>
+    /// <param name="hwnd">Handle to the window.</param>
+    /// <param name="isDarkMode">True to use dark immersive colors, false to use light immersive colors.</param>
+    /// <returns>True if the attribute was set successfully, false if unsupported or failed.</returns>
+    public static bool SetWindowImmersiveTheme(nint hwnd, bool isDarkMode)
+    {
+        if (hwnd == 0 || !ImmersiveThemeSupportedByVersion)
+        {
+            return false;
+        }
+
+        int value = isDarkMode ? 1 : 0;
+        int result = DwmSetWindowAttribute(hwnd, ImmersiveAttribute, ref value, sizeof(int));
+        bool success = result >= 0;
+
+        if (success && !Is11OrGreater)
+        {
+            bool isActive = User32.GetForegroundWindow() == hwnd;
+            int targetState = isActive ? 1 : 0;
+            int toggleState = isActive ? 0 : 1;
+
+            //Workaround for Windows 10
+            // Force the non-client area to refresh by toggling activation and restoring the actual state
+            User32.SendMessage(hwnd, WindowMessages.WM_NCACTIVATE, toggleState, 0);
+            User32.SendMessage(hwnd, WindowMessages.WM_NCACTIVATE, targetState, 0);
+        }
+
+        return success;
+    }
+}

--- a/src/MewUI/Platform/Win32/Win32TitleBarThemeSynchronizer.cs
+++ b/src/MewUI/Platform/Win32/Win32TitleBarThemeSynchronizer.cs
@@ -1,0 +1,68 @@
+﻿namespace Aprillz.MewUI.Platform.Win32;
+
+/// <summary>
+/// Manages synchronization of the Win32 window title bar appearance with application themes.
+/// </summary>
+internal sealed class Win32TitleBarThemeSynchronizer : IDisposable
+{
+    private nint _hWnd;
+    private bool _isSubscribed;
+
+    /// <summary>
+    /// Initializes the synchronizer and begins tracking theme changes for the specified window.
+    /// </summary>
+    /// <param name="hWnd">The window handle to synchronize.</param>
+    public void Initialize(nint hWnd)
+    {
+        if (hWnd == 0)
+        {
+            throw new ArgumentException("Invalid window handle.", nameof(hWnd));
+        }
+
+        if (!Win32ImmersiveThemeManager.IsImmersiveThemeSupportedByVersion())
+        {
+            return;
+        }
+
+        _hWnd = hWnd;
+
+        ApplyTheme(Application.Current.Theme);
+
+        if (!_isSubscribed)
+        {
+            Application.Current.ThemeChanged += OnThemeChanged;
+            _isSubscribed = true;
+        }
+    }
+
+    /// <summary>
+    /// Synchronizes the window's title bar appearance with the specified theme.
+    /// </summary>
+    /// <param name="theme">The theme to apply to the title bar.</param>
+    public void ApplyTheme(Theme theme)
+    {
+        if (_hWnd == 0)
+        {
+            return;
+        }
+
+        bool isDark = Palette.IsDarkBackground(theme.Palette.WindowBackground);
+        Win32ImmersiveThemeManager.SetWindowImmersiveTheme(_hWnd, isDark);
+    }
+
+    private void OnThemeChanged(Theme oldTheme, Theme newTheme)
+    {
+        ApplyTheme(newTheme);
+    }
+
+    public void Dispose()
+    {
+        if (_isSubscribed)
+        {
+            Application.Current.ThemeChanged -= OnThemeChanged;
+            _isSubscribed = false;
+        }
+
+        _hWnd = 0;
+    }
+}

--- a/src/MewUI/Platform/Win32/Win32WindowBackend.cs
+++ b/src/MewUI/Platform/Win32/Win32WindowBackend.cs
@@ -21,6 +21,8 @@ internal sealed class Win32WindowBackend : IWindowBackend
 
     public nint Handle { get; private set; }
 
+    private readonly Win32TitleBarThemeSynchronizer _titleBarThemeSync = new();
+
     internal Win32WindowBackend(Win32PlatformHost host, Window window)
     {
         _host = host;
@@ -282,6 +284,7 @@ internal sealed class Win32WindowBackend : IWindowBackend
         _host.RegisterWindow(Handle, this);
         Window.AttachBackend(this);
         ApplyResizeMode();
+        _titleBarThemeSync.Initialize(Handle);
 
         uint actualDpi = User32.GetDpiForWindow(Handle);
         if (actualDpi != initialDpi)
@@ -411,6 +414,7 @@ internal sealed class Win32WindowBackend : IWindowBackend
 
     private void HandleDestroy()
     {
+        _titleBarThemeSync.Dispose();
         DestroyIcons();
         if (Window.GraphicsFactory is Aprillz.MewUI.Rendering.IWindowResourceReleaser releaser)
         {
@@ -764,6 +768,7 @@ internal sealed class Win32WindowBackend : IWindowBackend
 
     public void Dispose()
     {
+        _titleBarThemeSync.Dispose();
         DestroyIcons();
         if (Handle != 0)
         {


### PR DESCRIPTION
This pull request adds support for synchronizing the Win32 window title bar appearance with the application theme, including immersive dark mode on Windows 10 and later.

It adds native interop for DWM window attributes, implements a theme manager for immersive mode, and integrates these capabilities into the Win32 window backend, ensuring proper resource cleanup.

**Immersive Theme Support and Synchronization:**

* Added `Dwmapi` interop class to support setting immersive dark mode attributes on Win32 windows using `DwmSetWindowAttribute` and related enumerations.
* Implemented `Win32ImmersiveThemeManager` for checking OS support and enabling immersive dark mode for window title bars, including a workaround for Windows 10 activation issues.
* Added `Win32TitleBarThemeSynchronizer` to track application theme changes and synchronize the window title bar appearance accordingly, with proper subscription and disposal logic.

**Integration with Win32 Window Backend:**

* Integrated `Win32TitleBarThemeSynchronizer` into `Win32WindowBackend`, initializing it after window creation and disposing of it during window destruction and backend disposal to ensure resources are managed correctly.

**Win32 Interop Additions:**

* Added `GetForegroundWindow` to the `User32` interop class, supporting activation logic required for immersive theme workarounds.… Win32 windows

**Tested on the following environments**:
 * Windows 10 version 22H2 (OS Build 19045.6809)
 * Windows 11 version 25H2 (OS Build 26200.7623)
 
**Screenshots**

Windows 10:
| Bevore                                                                                      | After                                                                                      |
|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
| ![Image 1](https://github.com/user-attachments/assets/56ec0b50-d9cc-4a1a-b927-8c32c777b5b8) | ![Image 2](https://github.com/user-attachments/assets/d89e42f3-0858-4d2a-9768-8d7e5c179cc2) |

Windows 11:
| Bevore                                                                                      | After                                                                                      |
|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
| ![Image 1](https://github.com/user-attachments/assets/c26578ff-26d5-41e3-929f-3525f3fdb6e8) | ![Image 2](https://github.com/user-attachments/assets/589fde72-b48f-4c99-9676-700c5b4d0bc4) |
