### PR TITLE
Add Drawing, Skia in GraphicsBackend.cs, to support other backend implementations

### DIFF
--- a/src/MewUI/Rendering/GraphicsBackend.cs
+++ b/src/MewUI/Rendering/GraphicsBackend.cs
@@ -10,4 +10,6 @@ public enum GraphicsBackend
     Gdi,
     OpenGL,
     Metal,
+    Drawing,
+    Skia
 }


### PR DESCRIPTION
Hello,
MewUI is an excellent and great project. I believe it will become the best .net light crossplatform UI!👍
I try to to implement some backend implementations for portable or crossplatform purpose.
So I forked an MewUI project in https://github.com/shonescript/MewUI, and has one dependant on GraphicsBackend enum in the main project.
Is there a chance to extend it？🙂