### PR TITLE
feat(Calendar, DatePicker): Add culture/calendar support with DateOnly migration

### DIFF
--- a/samples/MewUI.Gallery/GalleryView.Selection.cs
+++ b/samples/MewUI.Gallery/GalleryView.Selection.cs
@@ -79,15 +79,28 @@ partial class GalleryView
                         .Spacing(8)
                         .Children(
                             new ComboBox()
-                                .Items(["Default", "Gregorian Calendar", "Persian Calendar"])
+                                .Items(["Default", "Persian (fa-IR)", "Arabic (ar-SA)", "Hebrew (he-IL)", "Japanese (ja-JP)", "Korean (ko-KR)", "Taiwan (zh-TW)", "Thai (th-TH)"])
                                 .SelectedIndex(0)
                                 .OnSelectionChanged(x => {
-                                    calendar.CalendarSystem = x switch {
-                                        "Gregorian Calendar" => new System.Globalization.GregorianCalendar(),
-                                        "Persian Calendar" => new System.Globalization.PersianCalendar(),
-                                        _ => null
+                                    var culture = x switch {
+                                        "Persian (fa-IR)"  => System.Globalization.CultureInfo.GetCultureInfo("fa-IR"),
+                                        "Arabic (ar-SA)"   => System.Globalization.CultureInfo.GetCultureInfo("ar-SA"),
+                                        "Hebrew (he-IL)"   => System.Globalization.CultureInfo.GetCultureInfo("he-IL"),
+                                        "Japanese (ja-JP)" => System.Globalization.CultureInfo.GetCultureInfo("ja-JP"),
+                                        "Korean (ko-KR)"   => System.Globalization.CultureInfo.GetCultureInfo("ko-KR"),
+                                        "Taiwan (zh-TW)"   => System.Globalization.CultureInfo.GetCultureInfo("zh-TW"),
+                                        "Thai (th-TH)"     => System.Globalization.CultureInfo.GetCultureInfo("th-TH"),
+                                        _ => (System.Globalization.CultureInfo?)null
                                     };
-                                    datePicker.CalendarSystem = calendar.CalendarSystem;
+                                    calendar.DisplayCulture = culture;
+                                    datePicker.DisplayCulture = culture;
+                                }),
+
+                        new CheckBox()
+                                .Content("Gregorian")
+                                .OnCheckedChanged(v => {
+                                    calendar.UseGregorianCalendar = v == true;
+                                    datePicker.UseGregorianCalendar = v == true;
                                 }),
 
                             new TextBlock()

--- a/samples/MewUI.Gallery/GalleryView.Selection.cs
+++ b/samples/MewUI.Gallery/GalleryView.Selection.cs
@@ -4,6 +4,8 @@ namespace Aprillz.MewUI.Gallery;
 
 partial class GalleryView
 {
+    DatePicker datePicker = null!;
+
     private FrameworkElement SelectionPage()
     {
         var items = Enumerable.Range(1, 20).Select(i => $"Item {i}").Append("Item Long Long Long Long Long Long Long").ToArray();
@@ -72,8 +74,25 @@ partial class GalleryView
                         new Calendar()
                             .Ref(out calendar),
 
-                        new TextBlock()
-                            .Bind(TextBlock.TextProperty, calendar, Calendar.SelectedDateProperty, x => $"Selected: {x:yyyy-MM-dd}")
+                        new StackPanel()
+                        .Horizontal()
+                        .Spacing(8)
+                        .Children(
+                            new ComboBox()
+                                .Items(["Default", "Gregorian Calendar", "Persian Calendar"])
+                                .SelectedIndex(0)
+                                .OnSelectionChanged(x => {
+                                    calendar.CalendarSystem = x switch {
+                                        "Gregorian Calendar" => new System.Globalization.GregorianCalendar(),
+                                        "Persian Calendar" => new System.Globalization.PersianCalendar(),
+                                        _ => null
+                                    };
+                                    datePicker.CalendarSystem = calendar.CalendarSystem;
+                                }),
+
+                            new TextBlock()
+                                .Bind(TextBlock.TextProperty, calendar, Calendar.SelectedDateProperty, x => $"Selected: {x:yyyy-MM-dd}")
+                        )
                     )
             ),
 
@@ -84,7 +103,7 @@ partial class GalleryView
                     .Spacing(8)
                     .Children(
                         new DatePicker().Placeholder("Select a date..."),
-                        new DatePicker().SelectedDate(DateTime.Today),
+                        new DatePicker().Ref(out datePicker).SelectedDate(DateOnly.FromDateTime(DateTime.Today)),
                         new DatePicker().Placeholder("Disabled").Disable()
                     ),
                 minWidth: 250

--- a/src/MewUI/Controls/Calendar.cs
+++ b/src/MewUI/Controls/Calendar.cs
@@ -72,8 +72,8 @@ public sealed class Calendar : Control, IVisualTreeHost
             MewPropertyOptions.AffectsRender,
             static (self, _, _) => self.InvalidateHeaderCache());
 
-    public static readonly MewProperty<System.Globalization.Calendar?> CalendarSystemProperty =
-        MewProperty<System.Globalization.Calendar?>.Register<Calendar>(nameof(CalendarSystem), null,
+    public static readonly MewProperty<bool> UseGregorianCalendarProperty =
+        MewProperty<bool>.Register<Calendar>(nameof(UseGregorianCalendar), false,
             MewPropertyOptions.AffectsRender,
             static (self, _, _) => self.InvalidateHeaderCache());
 
@@ -162,15 +162,15 @@ public sealed class Calendar : Control, IVisualTreeHost
     }
 
     /// <summary>
-    /// Gets or sets the calendar system used for date calculations
-    /// (e.g. <see cref="System.Globalization.PersianCalendar"/>).
-    /// If <see langword="null"/>, the calendar of <see cref="DisplayCulture"/>
+    /// Gets or sets whether the Gregorian calendar is used for date calculations,
+    /// regardless of the <see cref="DisplayCulture"/> setting.
+    /// When <see langword="false"/> (default), the calendar of <see cref="DisplayCulture"/>
     /// (or <see cref="CultureInfo.CurrentCulture"/>) is used.
     /// </summary>
-    public System.Globalization.Calendar? CalendarSystem
+    public bool UseGregorianCalendar
     {
-        get => GetValue(CalendarSystemProperty);
-        set => SetValue(CalendarSystemProperty, value);
+        get => GetValue(UseGregorianCalendarProperty);
+        set => SetValue(UseGregorianCalendarProperty, value);
     }
 
     public override bool Focusable => true;
@@ -209,8 +209,10 @@ public sealed class Calendar : Control, IVisualTreeHost
     private CultureInfo GetEffectiveCulture() =>
         DisplayCulture ?? CultureInfo.CurrentCulture;
 
+    private static readonly System.Globalization.GregorianCalendar _sharedGregorianCalendar = new();
+
     private System.Globalization.Calendar GetEffectiveCalendar() =>
-        CalendarSystem ?? GetEffectiveCulture().Calendar;
+        UseGregorianCalendar ? _sharedGregorianCalendar : GetEffectiveCulture().Calendar;
 
     private static DateTime ToDateTimeForCal(DateOnly d) =>
         d.ToDateTime(TimeOnly.MinValue);

--- a/src/MewUI/Controls/Calendar.cs
+++ b/src/MewUI/Controls/Calendar.cs
@@ -31,7 +31,7 @@ public sealed class Calendar : Control, IVisualTreeHost
     private readonly Button _headerButton; // "March 2026" — click to switch mode
 
     // Cached header text
-    private DateTime _cachedHeaderDate;
+    private DateOnly _cachedHeaderDate;
     private CalendarMode _cachedHeaderMode = (CalendarMode)(-1);
 
     // Cached cell rects for hit testing
@@ -45,13 +45,13 @@ public sealed class Calendar : Control, IVisualTreeHost
     private IFont? _dowFont;
     private uint _cellFontDpi;
 
-    public static readonly MewProperty<DateTime?> SelectedDateProperty =
-        MewProperty<DateTime?>.Register<Calendar>(nameof(SelectedDate), null,
+    public static readonly MewProperty<DateOnly?> SelectedDateProperty =
+        MewProperty<DateOnly?>.Register<Calendar>(nameof(SelectedDate), null,
             MewPropertyOptions.AffectsRender,
             static (self, oldValue, newValue) => self.OnSelectedDateChanged(oldValue, newValue));
 
-    public static readonly MewProperty<DateTime> DisplayDateProperty =
-        MewProperty<DateTime>.Register<Calendar>(nameof(DisplayDate), DateTime.Today,
+    public static readonly MewProperty<DateOnly> DisplayDateProperty =
+        MewProperty<DateOnly>.Register<Calendar>(nameof(DisplayDate), DateOnly.FromDateTime(DateTime.Today),
             MewPropertyOptions.AffectsRender);
 
     public static readonly MewProperty<CalendarMode> DisplayModeProperty =
@@ -66,6 +66,16 @@ public sealed class Calendar : Control, IVisualTreeHost
     public static readonly MewProperty<bool> IsTodayHighlightedProperty =
         MewProperty<bool>.Register<Calendar>(nameof(IsTodayHighlighted), true,
             MewPropertyOptions.AffectsRender);
+
+    public static readonly MewProperty<CultureInfo?> DisplayCultureProperty =
+        MewProperty<CultureInfo?>.Register<Calendar>(nameof(DisplayCulture), null,
+            MewPropertyOptions.AffectsRender,
+            static (self, _, _) => self.InvalidateHeaderCache());
+
+    public static readonly MewProperty<System.Globalization.Calendar?> CalendarSystemProperty =
+        MewProperty<System.Globalization.Calendar?>.Register<Calendar>(nameof(CalendarSystem), null,
+            MewPropertyOptions.AffectsRender,
+            static (self, _, _) => self.InvalidateHeaderCache());
 
     public Calendar()
     {
@@ -107,14 +117,14 @@ public sealed class Calendar : Control, IVisualTreeHost
     }
 
     /// <summary>Gets or sets the selected date.</summary>
-    public DateTime? SelectedDate
+    public DateOnly? SelectedDate
     {
         get => GetValue(SelectedDateProperty);
         set => SetValue(SelectedDateProperty, value);
     }
 
     /// <summary>Gets or sets the month/year currently displayed.</summary>
-    public DateTime DisplayDate
+    public DateOnly DisplayDate
     {
         get => GetValue(DisplayDateProperty);
         set => SetValue(DisplayDateProperty, value);
@@ -141,18 +151,40 @@ public sealed class Calendar : Control, IVisualTreeHost
         set => SetValue(IsTodayHighlightedProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the culture used for display (month/day names, number formatting).
+    /// If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.
+    /// </summary>
+    public CultureInfo? DisplayCulture
+    {
+        get => GetValue(DisplayCultureProperty);
+        set => SetValue(DisplayCultureProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the calendar system used for date calculations
+    /// (e.g. <see cref="System.Globalization.PersianCalendar"/>).
+    /// If <see langword="null"/>, the calendar of <see cref="DisplayCulture"/>
+    /// (or <see cref="CultureInfo.CurrentCulture"/>) is used.
+    /// </summary>
+    public System.Globalization.Calendar? CalendarSystem
+    {
+        get => GetValue(CalendarSystemProperty);
+        set => SetValue(CalendarSystemProperty, value);
+    }
+
     public override bool Focusable => true;
 
     /// <summary>Raised when <see cref="SelectedDate"/> changes (keyboard navigation or click).</summary>
-    public event Action<DateTime?>? SelectedDateChanged;
+    public event Action<DateOnly?>? SelectedDateChanged;
 
     /// <summary>Raised when a date is activated by mouse click or Enter key (commit action).</summary>
-    public event Action<DateTime>? DateActivated;
+    public event Action<DateOnly>? DateActivated;
 
     /// <summary>Raised when <see cref="DisplayMode"/> changes.</summary>
     public event Action<CalendarMode>? DisplayModeChanged;
 
-    private void OnSelectedDateChanged(DateTime? oldValue, DateTime? newValue)
+    private void OnSelectedDateChanged(DateOnly? oldValue, DateOnly? newValue)
     {
         if (newValue.HasValue)
         {
@@ -166,6 +198,60 @@ public sealed class Calendar : Control, IVisualTreeHost
     {
         DisplayModeChanged?.Invoke(newValue);
     }
+
+    private void InvalidateHeaderCache()
+    {
+        _cachedHeaderMode = (CalendarMode)(-1);
+    }
+
+    #region Calendar Helpers
+
+    private CultureInfo GetEffectiveCulture() =>
+        DisplayCulture ?? CultureInfo.CurrentCulture;
+
+    private System.Globalization.Calendar GetEffectiveCalendar() =>
+        CalendarSystem ?? GetEffectiveCulture().Calendar;
+
+    private static DateTime ToDateTimeForCal(DateOnly d) =>
+        d.ToDateTime(TimeOnly.MinValue);
+
+    private DateOnly FirstOfCalendarMonth(int calYear, int calMonth) =>
+        DateOnly.FromDateTime(new DateTime(calYear, calMonth, 1, GetEffectiveCalendar()));
+
+    /// <summary>
+    /// Returns a <see cref="DateTimeFormatInfo"/> whose <see cref="DateTimeFormatInfo.Calendar"/>
+    /// matches <see cref="GetEffectiveCalendar"/>, cloning only when necessary.
+    /// </summary>
+    private DateTimeFormatInfo GetEffectiveDateTimeFormat()
+    {
+        var culture = GetEffectiveCulture();
+        var cal = GetEffectiveCalendar();
+        var dtf = culture.DateTimeFormat;
+        if (dtf.Calendar.GetType() == cal.GetType())
+            return dtf;
+
+        dtf = (DateTimeFormatInfo)dtf.Clone();
+        try { dtf.Calendar = cal; }
+        catch { /* fall back to culture DTF if calendar not compatible */ }
+        return dtf;
+    }
+
+    private string GetCalendarMonthName(int calYear, int calMonth, bool abbreviated)
+    {
+        var cal = GetEffectiveCalendar();
+        try
+        {
+            var dtf = GetEffectiveDateTimeFormat();
+            var dt = new DateTime(calYear, calMonth, 1, cal);
+            return dt.ToString(abbreviated ? "MMM" : "MMMM", dtf);
+        }
+        catch
+        {
+            return calMonth.ToString();
+        }
+    }
+
+    #endregion
 
     #region Layout
 
@@ -307,12 +393,18 @@ public sealed class Calendar : Control, IVisualTreeHost
         _cachedHeaderDate = display;
         _cachedHeaderMode = mode;
 
+        var cal = GetEffectiveCalendar();
+        var culture = GetEffectiveCulture();
+        var dt = ToDateTimeForCal(display);
+        int calYear = cal.GetYear(dt);
+        int calMonth = cal.GetMonth(dt);
+
         var label = (TextBlock)_headerButton.Content!;
         label.Text = mode switch
         {
-            CalendarMode.Month => display.ToString("Y", CultureInfo.CurrentCulture),
-            CalendarMode.Year => display.ToString("yyyy", CultureInfo.CurrentCulture),
-            CalendarMode.Decade => $"{display.Year / 10 * 10}–{display.Year / 10 * 10 + 9}",
+            CalendarMode.Month => $"{GetCalendarMonthName(calYear, calMonth, abbreviated: false)} {calYear}",
+            CalendarMode.Year => calYear.ToString(culture),
+            CalendarMode.Decade => $"{calYear / 10 * 10}\u2013{calYear / 10 * 10 + 9}",
             _ => string.Empty,
         };
     }
@@ -322,12 +414,17 @@ public sealed class Calendar : Control, IVisualTreeHost
         var theme = Theme;
         var palette = theme.Palette;
         var font = GetCellFont();
-        var today = DateTime.Today;
+        var cal = GetEffectiveCalendar();
+        var culture = GetEffectiveCulture();
         double dpiScale = GetDpi() / 96.0;
         double snappedRadius = LayoutRounding.RoundToPixel(CellCornerRadius, dpiScale);
         double snappedStroke = LayoutRounding.SnapThicknessToPixels(TodayStrokeThickness, dpiScale, 1);
         var display = DisplayDate;
         var selected = SelectedDate;
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var displayDt = ToDateTimeForCal(display);
+        int calYear = cal.GetYear(displayDt);
+        int calMonth = cal.GetMonth(displayDt);
 
         // Day of week headers
         var inner = GetInnerBounds();
@@ -338,7 +435,7 @@ public sealed class Calendar : Control, IVisualTreeHost
         for (int i = 0; i < DaysPerWeek; i++)
         {
             var dow = (DayOfWeek)(((int)fdow + i) % DaysPerWeek);
-            string dayName = CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedDayName(dow);
+            string dayName = culture.DateTimeFormat.GetAbbreviatedDayName(dow);
             if (dayName.Length > 2) dayName = dayName[..2];
 
             var rect = new Rect(
@@ -352,17 +449,21 @@ public sealed class Calendar : Control, IVisualTreeHost
         }
 
         // Day cells
-        var firstOfMonth = new DateTime(display.Year, display.Month, 1);
-        int startDow = ((int)firstOfMonth.DayOfWeek - (int)fdow + DaysPerWeek) % DaysPerWeek;
+        var firstOfMonth = FirstOfCalendarMonth(calYear, calMonth);
+        int startDow = ((int)cal.GetDayOfWeek(ToDateTimeForCal(firstOfMonth)) - (int)fdow + DaysPerWeek) % DaysPerWeek;
         var startDate = firstOfMonth.AddDays(-startDow);
 
         for (int i = 0; i < MonthCells; i++)
         {
             var date = startDate.AddDays(i);
+            var dateDt = ToDateTimeForCal(date);
+            int datCalYear = cal.GetYear(dateDt);
+            int datCalMonth = cal.GetMonth(dateDt);
+            int datCalDay = cal.GetDayOfMonth(dateDt);
             var cellRect = _cellRects[i];
-            bool isCurrentMonth = date.Month == display.Month && date.Year == display.Year;
+            bool isCurrentMonth = datCalYear == calYear && datCalMonth == calMonth;
             bool isToday = IsTodayHighlighted && date == today;
-            bool isSelected = selected.HasValue && date == selected.Value.Date;
+            bool isSelected = selected.HasValue && date == selected.Value;
             bool isHot = i == _hotCellIndex;
 
             var unit = Math.Min(cellRect.Width, cellRect.Height);
@@ -392,7 +493,7 @@ public sealed class Calendar : Control, IVisualTreeHost
                     ? palette.WindowText
                     : palette.DisabledText;
 
-            context.DrawText(date.Day.ToString(), cellRect, font, textColor,
+            context.DrawText(datCalDay.ToString(), cellRect, font, textColor,
                 TextAlignment.Center, TextAlignment.Center);
         }
     }
@@ -402,26 +503,34 @@ public sealed class Calendar : Control, IVisualTreeHost
         var theme = Theme;
         var palette = theme.Palette;
         var font = GetCellFont();
+        var cal = GetEffectiveCalendar();
         var display = DisplayDate;
         var selected = SelectedDate;
+        var displayDt = ToDateTimeForCal(display);
+        int calYear = cal.GetYear(displayDt);
+        int monthsInYear = cal.GetMonthsInYear(calYear);
+        int todayCalYear = cal.GetYear(DateTime.Today);
+        int todayCalMonth = cal.GetMonth(DateTime.Today);
         double dpiScale = GetDpi() / 96.0;
         double snappedRadius = LayoutRounding.RoundToPixel(CellCornerRadius, dpiScale);
         double snappedStroke = LayoutRounding.SnapThicknessToPixels(TodayStrokeThickness, dpiScale, 1);
 
         for (int i = 0; i < YearDecadeCells; i++)
         {
+            int month = i + 1;
+            if (month > monthsInYear) continue;
+
             var cellRect = _cellRects[i];
 
             var unit = Math.Min(cellRect.Width, cellRect.Height) - 2;
             var circleRect = new Rect(cellRect.X + (cellRect.Width - unit) / 2, cellRect.Y + (cellRect.Height - unit) / 2, unit, unit);
             snappedRadius = unit / 2.0;
 
-            int month = i + 1;
-            bool isSelected = selected.HasValue &&
-                              selected.Value.Year == display.Year &&
-                              selected.Value.Month == month;
+            bool isSelected = selected.HasValue
+                && cal.GetYear(ToDateTimeForCal(selected.Value)) == calYear
+                && cal.GetMonth(ToDateTimeForCal(selected.Value)) == month;
             bool isHot = i == _hotCellIndex;
-            bool isCurrent = DateTime.Today.Year == display.Year && DateTime.Today.Month == month;
+            bool isCurrent = todayCalYear == calYear && todayCalMonth == month;
 
             if (isSelected)
             {
@@ -438,7 +547,7 @@ public sealed class Calendar : Control, IVisualTreeHost
             }
 
             var textColor = isSelected ? palette.AccentText : palette.WindowText;
-            string label = CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(month);
+            string label = GetCalendarMonthName(calYear, month, abbreviated: true);
 
             context.DrawText(label, cellRect, font, textColor,
                 TextAlignment.Center, TextAlignment.Center);
@@ -450,9 +559,14 @@ public sealed class Calendar : Control, IVisualTreeHost
         var theme = Theme;
         var palette = theme.Palette;
         var font = GetCellFont();
+        var cal = GetEffectiveCalendar();
         var display = DisplayDate;
         var selected = SelectedDate;
-        int decadeStart = display.Year / 10 * 10;
+        int calYear = cal.GetYear(ToDateTimeForCal(display));
+        int decadeStart = calYear / 10 * 10;
+        int todayCalYear = cal.GetYear(DateTime.Today);
+        int minCalYear = cal.GetYear(cal.MinSupportedDateTime);
+        int maxCalYear = cal.GetYear(cal.MaxSupportedDateTime);
         double dpiScale = GetDpi() / 96.0;
         double snappedRadius = LayoutRounding.RoundToPixel(CellCornerRadius, dpiScale);
         double snappedStroke = LayoutRounding.SnapThicknessToPixels(TodayStrokeThickness, dpiScale, 1);
@@ -461,11 +575,12 @@ public sealed class Calendar : Control, IVisualTreeHost
         {
             var cellRect = _cellRects[i];
             int year = decadeStart - 1 + i; // decade: -1 to +10
-            bool isInDecade = year >= decadeStart && year < decadeStart + 10;
-            bool isSelected = selected.HasValue && selected.Value.Year == year;
+            bool isYearValid = year >= minCalYear && year <= maxCalYear;
+            bool isInDecade = isYearValid && year >= decadeStart && year < decadeStart + 10;
+            bool isSelected = isYearValid && selected.HasValue
+                && cal.GetYear(ToDateTimeForCal(selected.Value)) == year;
             bool isHot = i == _hotCellIndex;
-            bool isCurrent = DateTime.Today.Year == year;
-
+            bool isCurrent = isYearValid && todayCalYear == year;
 
             var unit = Math.Min(cellRect.Width, cellRect.Height) - 2;
             var circleRect = new Rect(cellRect.X + (cellRect.Width - unit) / 2, cellRect.Y + (cellRect.Height - unit) / 2, unit, unit);
@@ -502,32 +617,36 @@ public sealed class Calendar : Control, IVisualTreeHost
 
     private void OnPrevClick()
     {
+        var cal = GetEffectiveCalendar();
+        var dt = ToDateTimeForCal(DisplayDate);
         switch (DisplayMode)
         {
             case CalendarMode.Month:
-                DisplayDate = DisplayDate.AddMonths(-1);
+                DisplayDate = DateOnly.FromDateTime(cal.AddMonths(dt, -1));
                 break;
             case CalendarMode.Year:
-                DisplayDate = DisplayDate.AddYears(-1);
+                DisplayDate = DateOnly.FromDateTime(cal.AddYears(dt, -1));
                 break;
             case CalendarMode.Decade:
-                DisplayDate = DisplayDate.AddYears(-10);
+                DisplayDate = DateOnly.FromDateTime(cal.AddYears(dt, -10));
                 break;
         }
     }
 
     private void OnNextClick()
     {
+        var cal = GetEffectiveCalendar();
+        var dt = ToDateTimeForCal(DisplayDate);
         switch (DisplayMode)
         {
             case CalendarMode.Month:
-                DisplayDate = DisplayDate.AddMonths(1);
+                DisplayDate = DateOnly.FromDateTime(cal.AddMonths(dt, 1));
                 break;
             case CalendarMode.Year:
-                DisplayDate = DisplayDate.AddYears(1);
+                DisplayDate = DateOnly.FromDateTime(cal.AddYears(dt, 1));
                 break;
             case CalendarMode.Decade:
-                DisplayDate = DisplayDate.AddYears(10);
+                DisplayDate = DateOnly.FromDateTime(cal.AddYears(dt, 10));
                 break;
         }
     }
@@ -605,37 +724,45 @@ public sealed class Calendar : Control, IVisualTreeHost
 
     private void HandleCellActivated(int cellIndex)
     {
+        var cal = GetEffectiveCalendar();
         switch (DisplayMode)
         {
             case CalendarMode.Month:
             {
-                var firstOfMonth = new DateTime(DisplayDate.Year, DisplayDate.Month, 1);
-                int startDow = ((int)firstOfMonth.DayOfWeek - (int)FirstDayOfWeek + DaysPerWeek) % DaysPerWeek;
+                int calYear = cal.GetYear(ToDateTimeForCal(DisplayDate));
+                int calMonth = cal.GetMonth(ToDateTimeForCal(DisplayDate));
+                var firstOfMonth = FirstOfCalendarMonth(calYear, calMonth);
+                int startDow = ((int)cal.GetDayOfWeek(ToDateTimeForCal(firstOfMonth)) - (int)FirstDayOfWeek + DaysPerWeek) % DaysPerWeek;
                 var date = firstOfMonth.AddDays(cellIndex - startDow);
-                SelectedDate = date.Date;
-                // Navigate to the selected date's month if different
-                if (date.Month != DisplayDate.Month || date.Year != DisplayDate.Year)
-                    DisplayDate = new DateTime(date.Year, date.Month, 1);
-                DateActivated?.Invoke(date.Date);
+                SelectedDate = date;
+                int datCalYear = cal.GetYear(ToDateTimeForCal(date));
+                int datCalMonth = cal.GetMonth(ToDateTimeForCal(date));
+                if (datCalMonth != calMonth || datCalYear != calYear)
+                    DisplayDate = FirstOfCalendarMonth(datCalYear, datCalMonth);
+                DateActivated?.Invoke(date);
                 break;
             }
             case CalendarMode.Year:
             {
                 int month = cellIndex + 1;
-                if (month >= 1 && month <= 12)
+                int calYear = cal.GetYear(ToDateTimeForCal(DisplayDate));
+                if (month >= 1 && month <= cal.GetMonthsInYear(calYear))
                 {
-                    DisplayDate = new DateTime(DisplayDate.Year, month, 1);
+                    DisplayDate = FirstOfCalendarMonth(calYear, month);
                     DisplayMode = CalendarMode.Month;
                 }
                 break;
             }
             case CalendarMode.Decade:
             {
-                int decadeStart = DisplayDate.Year / 10 * 10;
+                int calYear = cal.GetYear(ToDateTimeForCal(DisplayDate));
+                int decadeStart = calYear / 10 * 10;
                 int year = decadeStart - 1 + cellIndex;
-                if (year >= 1 && year <= 9999)
+                int minCalYear = cal.GetYear(cal.MinSupportedDateTime);
+                int maxCalYear = cal.GetYear(cal.MaxSupportedDateTime);
+                if (year >= minCalYear && year <= maxCalYear)
                 {
-                    DisplayDate = new DateTime(year, DisplayDate.Month, 1);
+                    DisplayDate = FirstOfCalendarMonth(year, cal.GetMonth(ToDateTimeForCal(DisplayDate)));
                     DisplayMode = CalendarMode.Year;
                 }
                 break;
@@ -666,6 +793,7 @@ public sealed class Calendar : Control, IVisualTreeHost
 
     private void HandleMonthKeyDown(KeyEventArgs e)
     {
+        var cal = GetEffectiveCalendar();
         var current = SelectedDate ?? DisplayDate;
 
         switch (e.Key)
@@ -687,21 +815,30 @@ public sealed class Calendar : Control, IVisualTreeHost
                 e.Handled = true;
                 break;
             case Key.PageUp:
-                SelectedDate = current.AddMonths(-1);
+                SelectedDate = DateOnly.FromDateTime(cal.AddMonths(ToDateTimeForCal(current), -1));
                 e.Handled = true;
                 break;
             case Key.PageDown:
-                SelectedDate = current.AddMonths(1);
+                SelectedDate = DateOnly.FromDateTime(cal.AddMonths(ToDateTimeForCal(current), 1));
                 e.Handled = true;
                 break;
             case Key.Home:
-                SelectedDate = new DateTime(current.Year, current.Month, 1);
+            {
+                int calYear = cal.GetYear(ToDateTimeForCal(current));
+                int calMonth = cal.GetMonth(ToDateTimeForCal(current));
+                SelectedDate = FirstOfCalendarMonth(calYear, calMonth);
                 e.Handled = true;
                 break;
+            }
             case Key.End:
-                SelectedDate = new DateTime(current.Year, current.Month, DateTime.DaysInMonth(current.Year, current.Month));
+            {
+                int calYear = cal.GetYear(ToDateTimeForCal(current));
+                int calMonth = cal.GetMonth(ToDateTimeForCal(current));
+                int daysInMonth = cal.GetDaysInMonth(calYear, calMonth);
+                SelectedDate = new DateOnly(calYear, calMonth, daysInMonth, cal);
                 e.Handled = true;
                 break;
+            }
             case Key.Enter:
             case Key.Space:
                 if (SelectedDate.HasValue)
@@ -755,10 +892,12 @@ public sealed class Calendar : Control, IVisualTreeHost
 
     private void NavigateDisplayDate(int offset)
     {
+        var cal = GetEffectiveCalendar();
+        var dt = ToDateTimeForCal(DisplayDate);
         if (DisplayMode == CalendarMode.Year)
-            DisplayDate = DisplayDate.AddMonths(offset);
+            DisplayDate = DateOnly.FromDateTime(cal.AddMonths(dt, offset));
         else if (DisplayMode == CalendarMode.Decade)
-            DisplayDate = DisplayDate.AddYears(offset);
+            DisplayDate = DateOnly.FromDateTime(cal.AddYears(dt, offset));
     }
 
     #endregion

--- a/src/MewUI/Controls/DatePicker.cs
+++ b/src/MewUI/Controls/DatePicker.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Aprillz.MewUI.Rendering;
 
 namespace Aprillz.MewUI.Controls;
@@ -8,12 +9,12 @@ namespace Aprillz.MewUI.Controls;
 public sealed class DatePicker : DropDownBase
 {
     private Calendar? _calendar;
-    private DateTime? _cachedHeaderDate;
+    private DateOnly? _cachedHeaderDate;
     private string? _cachedHeaderFormat;
     private string? _cachedHeaderText;
 
-    public static readonly MewProperty<DateTime?> SelectedDateProperty =
-        MewProperty<DateTime?>.Register<DatePicker>(nameof(SelectedDate), null,
+    public static readonly MewProperty<DateOnly?> SelectedDateProperty =
+        MewProperty<DateOnly?>.Register<DatePicker>(nameof(SelectedDate), null,
             MewPropertyOptions.AffectsRender | MewPropertyOptions.BindsTwoWayByDefault,
             static (self, oldValue, newValue) => self.OnSelectedDatePropertyChanged(oldValue, newValue));
 
@@ -26,8 +27,18 @@ public sealed class DatePicker : DropDownBase
     public static readonly MewProperty<DayOfWeek> FirstDayOfWeekProperty =
         MewProperty<DayOfWeek>.Register<DatePicker>(nameof(FirstDayOfWeek), DayOfWeek.Sunday);
 
+    public static readonly MewProperty<CultureInfo?> DisplayCultureProperty =
+        MewProperty<CultureInfo?>.Register<DatePicker>(nameof(DisplayCulture), null,
+            MewPropertyOptions.AffectsRender,
+            static (self, _, _) => self._cachedHeaderText = null);
+
+    public static readonly MewProperty<System.Globalization.Calendar?> CalendarSystemProperty =
+        MewProperty<System.Globalization.Calendar?>.Register<DatePicker>(nameof(CalendarSystem), null,
+            MewPropertyOptions.AffectsRender,
+            static (self, _, _) => self._cachedHeaderText = null);
+
     /// <summary>Gets or sets the selected date.</summary>
-    public DateTime? SelectedDate
+    public DateOnly? SelectedDate
     {
         get => GetValue(SelectedDateProperty);
         set => SetValue(SelectedDateProperty, value);
@@ -54,10 +65,32 @@ public sealed class DatePicker : DropDownBase
         set => SetValue(FirstDayOfWeekProperty, value);
     }
 
-    /// <summary>Raised when the selected date changes.</summary>
-    public event Action<DateTime?>? SelectedDateChanged;
+    /// <summary>
+    /// Gets or sets the culture used for display (month/day names, number formatting).
+    /// If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.
+    /// </summary>
+    public CultureInfo? DisplayCulture
+    {
+        get => GetValue(DisplayCultureProperty);
+        set => SetValue(DisplayCultureProperty, value);
+    }
 
-    private void OnSelectedDatePropertyChanged(DateTime? oldValue, DateTime? newValue)
+    /// <summary>
+    /// Gets or sets the calendar system used for date calculations
+    /// (e.g. <see cref="System.Globalization.PersianCalendar"/>).
+    /// If <see langword="null"/>, the calendar of <see cref="DisplayCulture"/>
+    /// (or <see cref="CultureInfo.CurrentCulture"/>) is used.
+    /// </summary>
+    public System.Globalization.Calendar? CalendarSystem
+    {
+        get => GetValue(CalendarSystemProperty);
+        set => SetValue(CalendarSystemProperty, value);
+    }
+
+    /// <summary>Raised when the selected date changes.</summary>
+    public event Action<DateOnly?>? SelectedDateChanged;
+
+    private void OnSelectedDatePropertyChanged(DateOnly? oldValue, DateOnly? newValue)
     {
         if (_calendar != null)
             _calendar.SelectedDate = newValue;
@@ -70,6 +103,8 @@ public sealed class DatePicker : DropDownBase
         _calendar = new Calendar
         {
             FirstDayOfWeek = FirstDayOfWeek,
+            DisplayCulture = DisplayCulture,
+            CalendarSystem = CalendarSystem,
             StyleName = BuiltInStyles.DatePickerPopup,
         };
 
@@ -93,6 +128,8 @@ public sealed class DatePicker : DropDownBase
         if (_calendar == null) return;
 
         _calendar.FirstDayOfWeek = FirstDayOfWeek;
+        _calendar.DisplayCulture = DisplayCulture;
+        _calendar.CalendarSystem = CalendarSystem;
     }
 
     protected override void OnIsDropDownOpenChanged(bool oldValue, bool newValue)
@@ -114,7 +151,7 @@ public sealed class DatePicker : DropDownBase
 
     protected override UIElement GetPopupFocusTarget(UIElement popup) => popup;
 
-    private void OnCalendarSelectedDateChanged(DateTime? date)
+    private void OnCalendarSelectedDateChanged(DateOnly? date)
     {
         // Sync value during navigation (keyboard arrows) without closing popup.
         if (date.HasValue)
@@ -123,7 +160,7 @@ public sealed class DatePicker : DropDownBase
         }
     }
 
-    private void OnCalendarDateActivated(DateTime date)
+    private void OnCalendarDateActivated(DateOnly date)
     {
         // Commit action (mouse click or Enter key) — close popup.
         SelectedDate = date;
@@ -135,7 +172,7 @@ public sealed class DatePicker : DropDownBase
         var headerHeight = ResolveHeaderHeight();
 
         // Measure a representative date string to determine width
-        string sample = DateTime.Today.ToString(DateFormat);
+        string sample = DateOnly.FromDateTime(DateTime.Today).ToString(DateFormat);
         using var measure = BeginTextMeasurement();
         var textSize = measure.Context.MeasureText(sample, measure.Font);
 
@@ -159,11 +196,12 @@ public sealed class DatePicker : DropDownBase
         {
             var date = SelectedDate.Value;
             var fmt = DateFormat;
+            var culture = DisplayCulture ?? CultureInfo.CurrentCulture;
             if (_cachedHeaderText == null || _cachedHeaderDate != date || _cachedHeaderFormat != fmt)
             {
                 _cachedHeaderDate = date;
                 _cachedHeaderFormat = fmt;
-                _cachedHeaderText = date.ToString(fmt);
+                _cachedHeaderText = date.ToDateTime(TimeOnly.MinValue).ToString(fmt, culture);
             }
             text = _cachedHeaderText;
             textColor = state.IsEnabled ? Foreground : Theme.Palette.DisabledText;

--- a/src/MewUI/Controls/DatePicker.cs
+++ b/src/MewUI/Controls/DatePicker.cs
@@ -32,8 +32,8 @@ public sealed class DatePicker : DropDownBase
             MewPropertyOptions.AffectsRender,
             static (self, _, _) => self._cachedHeaderText = null);
 
-    public static readonly MewProperty<System.Globalization.Calendar?> CalendarSystemProperty =
-        MewProperty<System.Globalization.Calendar?>.Register<DatePicker>(nameof(CalendarSystem), null,
+    public static readonly MewProperty<bool> UseGregorianCalendarProperty =
+        MewProperty<bool>.Register<DatePicker>(nameof(UseGregorianCalendar), false,
             MewPropertyOptions.AffectsRender,
             static (self, _, _) => self._cachedHeaderText = null);
 
@@ -76,15 +76,15 @@ public sealed class DatePicker : DropDownBase
     }
 
     /// <summary>
-    /// Gets or sets the calendar system used for date calculations
-    /// (e.g. <see cref="System.Globalization.PersianCalendar"/>).
-    /// If <see langword="null"/>, the calendar of <see cref="DisplayCulture"/>
+    /// Gets or sets whether the Gregorian calendar is used for date calculations,
+    /// regardless of the <see cref="DisplayCulture"/> setting.
+    /// When <see langword="false"/> (default), the calendar of <see cref="DisplayCulture"/>
     /// (or <see cref="CultureInfo.CurrentCulture"/>) is used.
     /// </summary>
-    public System.Globalization.Calendar? CalendarSystem
+    public bool UseGregorianCalendar
     {
-        get => GetValue(CalendarSystemProperty);
-        set => SetValue(CalendarSystemProperty, value);
+        get => GetValue(UseGregorianCalendarProperty);
+        set => SetValue(UseGregorianCalendarProperty, value);
     }
 
     /// <summary>Raised when the selected date changes.</summary>
@@ -104,7 +104,7 @@ public sealed class DatePicker : DropDownBase
         {
             FirstDayOfWeek = FirstDayOfWeek,
             DisplayCulture = DisplayCulture,
-            CalendarSystem = CalendarSystem,
+            UseGregorianCalendar = UseGregorianCalendar,
             StyleName = BuiltInStyles.DatePickerPopup,
         };
 
@@ -129,7 +129,7 @@ public sealed class DatePicker : DropDownBase
 
         _calendar.FirstDayOfWeek = FirstDayOfWeek;
         _calendar.DisplayCulture = DisplayCulture;
-        _calendar.CalendarSystem = CalendarSystem;
+        _calendar.UseGregorianCalendar = UseGregorianCalendar;
     }
 
     protected override void OnIsDropDownOpenChanged(bool oldValue, bool newValue)
@@ -196,12 +196,23 @@ public sealed class DatePicker : DropDownBase
         {
             var date = SelectedDate.Value;
             var fmt = DateFormat;
-            var culture = DisplayCulture ?? CultureInfo.CurrentCulture;
+            var baseCulture = DisplayCulture ?? CultureInfo.CurrentCulture;
             if (_cachedHeaderText == null || _cachedHeaderDate != date || _cachedHeaderFormat != fmt)
             {
                 _cachedHeaderDate = date;
                 _cachedHeaderFormat = fmt;
-                _cachedHeaderText = date.ToDateTime(TimeOnly.MinValue).ToString(fmt, culture);
+                CultureInfo formatCulture;
+                if (UseGregorianCalendar && baseCulture.Calendar is not System.Globalization.GregorianCalendar)
+                {
+                    var cloned = (CultureInfo)baseCulture.Clone();
+                    cloned.DateTimeFormat.Calendar = new System.Globalization.GregorianCalendar();
+                    formatCulture = cloned;
+                }
+                else
+                {
+                    formatCulture = baseCulture;
+                }
+                _cachedHeaderText = date.ToDateTime(TimeOnly.MinValue).ToString(fmt, formatCulture);
             }
             text = _cachedHeaderText;
             textColor = state.IsEnabled ? Foreground : Theme.Palette.DisabledText;

--- a/src/MewUI/Markup/ControlExtensions.cs
+++ b/src/MewUI/Markup/ControlExtensions.cs
@@ -3138,7 +3138,7 @@ public static class ControlExtensions
     /// <summary>
     /// Sets the selected date.
     /// </summary>
-    public static Calendar SelectedDate(this Calendar calendar, DateTime? date)
+    public static Calendar SelectedDate(this Calendar calendar, DateOnly? date)
     {
         calendar.SelectedDate = date;
         return calendar;
@@ -3147,7 +3147,7 @@ public static class ControlExtensions
     /// <summary>
     /// Sets the display date (visible month/year).
     /// </summary>
-    public static Calendar DisplayDate(this Calendar calendar, DateTime date)
+    public static Calendar DisplayDate(this Calendar calendar, DateOnly date)
     {
         calendar.DisplayDate = date;
         return calendar;
@@ -3183,16 +3183,34 @@ public static class ControlExtensions
     /// <summary>
     /// Adds a selected date changed event handler.
     /// </summary>
-    public static Calendar OnSelectedDateChanged(this Calendar calendar, Action<DateTime?> handler)
+    public static Calendar OnSelectedDateChanged(this Calendar calendar, Action<DateOnly?> handler)
     {
         calendar.SelectedDateChanged += handler;
         return calendar;
     }
 
     /// <summary>
+    /// Sets the calendar system used for date calculations (e.g. PersianCalendar).
+    /// </summary>
+    public static Calendar CalendarSystem(this Calendar calendar, System.Globalization.Calendar? calendarSystem)
+    {
+        calendar.CalendarSystem = calendarSystem;
+        return calendar;
+    }
+
+    /// <summary>
+    /// Sets the culture used for display (month/day names, number formatting).
+    /// </summary>
+    public static Calendar DisplayCulture(this Calendar calendar, System.Globalization.CultureInfo? culture)
+    {
+        calendar.DisplayCulture = culture;
+        return calendar;
+    }
+
+    /// <summary>
     /// Binds the selected date to an observable value.
     /// </summary>
-    public static Calendar BindSelectedDate(this Calendar calendar, ObservableValue<DateTime?> source)
+    public static Calendar BindSelectedDate(this Calendar calendar, ObservableValue<DateOnly?> source)
     {
         ArgumentNullException.ThrowIfNull(calendar);
         ArgumentNullException.ThrowIfNull(source);
@@ -3208,7 +3226,7 @@ public static class ControlExtensions
     /// <summary>
     /// Sets the selected date.
     /// </summary>
-    public static DatePicker SelectedDate(this DatePicker datePicker, DateTime? date)
+    public static DatePicker SelectedDate(this DatePicker datePicker, DateOnly? date)
     {
         datePicker.SelectedDate = date;
         return datePicker;
@@ -3242,9 +3260,27 @@ public static class ControlExtensions
     }
 
     /// <summary>
+    /// Sets the calendar system used for date calculations (e.g. PersianCalendar).
+    /// </summary>
+    public static DatePicker CalendarSystem(this DatePicker datePicker, System.Globalization.Calendar? calendarSystem)
+    {
+        datePicker.CalendarSystem = calendarSystem;
+        return datePicker;
+    }
+
+    /// <summary>
+    /// Sets the culture used for display (month/day names, number formatting).
+    /// </summary>
+    public static DatePicker DisplayCulture(this DatePicker datePicker, System.Globalization.CultureInfo? culture)
+    {
+        datePicker.DisplayCulture = culture;
+        return datePicker;
+    }
+
+    /// <summary>
     /// Adds a selected date changed event handler.
     /// </summary>
-    public static DatePicker OnSelectedDateChanged(this DatePicker datePicker, Action<DateTime?> handler)
+    public static DatePicker OnSelectedDateChanged(this DatePicker datePicker, Action<DateOnly?> handler)
     {
         datePicker.SelectedDateChanged += handler;
         return datePicker;
@@ -3253,7 +3289,7 @@ public static class ControlExtensions
     /// <summary>
     /// Binds the selected date to an observable value.
     /// </summary>
-    public static DatePicker BindSelectedDate(this DatePicker datePicker, ObservableValue<DateTime?> source)
+    public static DatePicker BindSelectedDate(this DatePicker datePicker, ObservableValue<DateOnly?> source)
     {
         ArgumentNullException.ThrowIfNull(datePicker);
         ArgumentNullException.ThrowIfNull(source);

--- a/src/MewUI/Markup/ControlExtensions.cs
+++ b/src/MewUI/Markup/ControlExtensions.cs
@@ -3190,11 +3190,12 @@ public static class ControlExtensions
     }
 
     /// <summary>
-    /// Sets the calendar system used for date calculations (e.g. PersianCalendar).
+    /// Sets whether the Gregorian calendar is used for date calculations,
+    /// regardless of the <see cref="Calendar.DisplayCulture"/> setting.
     /// </summary>
-    public static Calendar CalendarSystem(this Calendar calendar, System.Globalization.Calendar? calendarSystem)
+    public static Calendar UseGregorianCalendar(this Calendar calendar, bool value = true)
     {
-        calendar.CalendarSystem = calendarSystem;
+        calendar.UseGregorianCalendar = value;
         return calendar;
     }
 
@@ -3260,11 +3261,12 @@ public static class ControlExtensions
     }
 
     /// <summary>
-    /// Sets the calendar system used for date calculations (e.g. PersianCalendar).
+    /// Sets whether the Gregorian calendar is used for date calculations,
+    /// regardless of the <see cref="DatePicker.DisplayCulture"/> setting.
     /// </summary>
-    public static DatePicker CalendarSystem(this DatePicker datePicker, System.Globalization.Calendar? calendarSystem)
+    public static DatePicker UseGregorianCalendar(this DatePicker datePicker, bool value = true)
     {
-        datePicker.CalendarSystem = calendarSystem;
+        datePicker.UseGregorianCalendar = value;
         return datePicker;
     }
 


### PR DESCRIPTION
## Summary

Migrate `Calendar` and `DatePicker` controls from `DateTime` to `DateOnly`, and add culture-aware rendering support via `DisplayCulture` and `UseGregorianCalendar` properties. This allows the calendar to display month/day names and date numbers according to any .NET-supported culture, and optionally override the native calendar with Gregorian while preserving the culture's language.

## Type of change

- [ ] Small bug fix
- [ ] Documentation or sample update
- [x] Behavior change
- [x] Public API or architectural change

## Related links

_No related issue. Change was discussed inline during development._

## Current behavior

- `SelectedDate` and `DisplayDate` on both `Calendar` and `DatePicker` were `DateTime`/`DateTime?`
- The calendar always rendered using the application's default culture and the Gregorian calendar
- Month names, day names, and date numbers had no culture-awareness
- There was no way to display Persian, Arabic, Hebrew, Japanese, or other calendar systems

## Proposed behavior

- `SelectedDate` and `DisplayDate` are now `DateOnly`/`DateOnly?` — more appropriate for date-only selection with no time component
- New `DisplayCulture` (`CultureInfo?`) property: month names, day names, and formatting follow the selected culture's native calendar (e.g. `fa-IR` → Persian month names and Persian digits)
- New `UseGregorianCalendar` (`bool`, default `false`) property: overrides the culture's native calendar with Gregorian while keeping the culture's language for labels (e.g. `fa-IR` + `UseGregorianCalendar=true` → Gregorian date numbers with Farsi month names)
- When neither property is set, behavior falls back to `CultureInfo.CurrentCulture` — fully backward compatible
- Header text is correctly invalidated and re-rendered whenever `DisplayCulture` or `UseGregorianCalendar` changes
- `DatePicker` popup `Calendar` is kept in sync with the picker's own `DisplayCulture` and `UseGregorianCalendar` settings
- Gallery sample updated with a culture `ComboBox` (8 cultures) and a `UseGregorianCalendar` `CheckBox`, both linked to the `Calendar` and `DatePicker` cards

## Validation

- [ ] Added or updated automated tests
- [x] Manually verified the change
- [ ] No test added

Manually verified in the Gallery app (`GalleryView.Selection`) by switching between all 8 cultures (`Default`, `fa-IR`, `ar-SA`, `he-IL`, `ja-JP`, `ko-KR`, `zh-TW`, `th-TH`) and toggling `UseGregorianCalendar` on/off for each combination. Verified that:
- Month names update immediately on culture/calendar change
- Date numbers are correct for both native and Gregorian modes
- `DatePicker` header reflects the same culture as the `Calendar`
- Default mode (no culture set) behaves identically to the previous version

No automated tests were added because the rendering logic depends on the visual pipeline and is not unit-testable without a rendering harness. Manual gallery validation covers the critical paths.

## Scope check

- [x] This PR is focused on one purpose.
- [x] I avoided unrelated refactoring.
- [x] I updated docs or samples when relevant.
- [x] I discussed the change first if it affects behavior, architecture, or public API.

> ⚠️ **Breaking change:** `SelectedDate` and `DisplayDate` are now `DateOnly`/`DateOnly?`. Any existing binding or assignment using `DateTime` must be updated (e.g. `DateOnly.FromDateTime(DateTime.Today)`).
